### PR TITLE
Allow multiple values to be substituted

### DIFF
--- a/lib/sepia/src/util.js
+++ b/lib/sepia/src/util.js
@@ -129,7 +129,10 @@ function substituteWithOpaqueKeys(text) {
   var substitutions = globalOptions.substitutions;
   for (var i=0; i<substitutions.length; i++) {
     var subst = substitutions[i];
-    text = text.replace(subst.actualValueFn(), subst.opaqueKey);
+    var actualValue = subst.actualValueFn();
+    while (text.indexOf(actualValue) > -1) {
+      text = text.replace(actualValue, subst.opaqueKey);
+    }
   }
   return text;
 }
@@ -138,7 +141,9 @@ function substituteWithRealValues(text) {
   var substitutions = globalOptions.substitutions;
   for (var i=0; i<substitutions.length; i++) {
     var subst = substitutions[i];
-    text = text.replace(subst.opaqueKey, subst.actualValueFn());
+    while (text.indexOf(subst.opaqueKey) > -1) {
+      text = text.replace(subst.opaqueKey, subst.actualValueFn());
+    }
   }
   return text;
 }

--- a/lib/sepia/src/util.js
+++ b/lib/sepia/src/util.js
@@ -18,7 +18,6 @@ var path = require('path');
 var crypto = require('crypto');
 var fs = require('fs');
 var Levenshtein = require('levenshtein');
-var escapeRegex = require('escape-string-regexp');
 
 const COLOR_RESET = '\033[0m';
 const COLOR_RED_BOLD = '\033[1;31m';
@@ -130,7 +129,7 @@ function substituteWithOpaqueKeys(text) {
   var substitutions = globalOptions.substitutions;
   for (var i=0; i<substitutions.length; i++) {
     var subst = substitutions[i];
-    text = text.replace(new RegExp(escapeRegex(subst.actualValueFn()), 'g'), subst.opaqueKey);
+    text = text.split(subst.actualValueFn()).join(subst.opaqueKey);
   }
   return text;
 }
@@ -139,7 +138,7 @@ function substituteWithRealValues(text) {
   var substitutions = globalOptions.substitutions;
   for (var i=0; i<substitutions.length; i++) {
     var subst = substitutions[i];
-    text = text.replace(new RegExp(escapeRegex(subst.opaqueKey), 'g'), subst.actualValueFn());
+    text = text.split(subst.opaqueKey).join(subst.actualValueFn());
   }
   return text;
 }

--- a/lib/sepia/src/util.js
+++ b/lib/sepia/src/util.js
@@ -18,6 +18,7 @@ var path = require('path');
 var crypto = require('crypto');
 var fs = require('fs');
 var Levenshtein = require('levenshtein');
+var escapeRegex = require('escape-string-regexp');
 
 const COLOR_RESET = '\033[0m';
 const COLOR_RED_BOLD = '\033[1;31m';
@@ -129,10 +130,7 @@ function substituteWithOpaqueKeys(text) {
   var substitutions = globalOptions.substitutions;
   for (var i=0; i<substitutions.length; i++) {
     var subst = substitutions[i];
-    var actualValue = subst.actualValueFn();
-    while (text.indexOf(actualValue) > -1) {
-      text = text.replace(actualValue, subst.opaqueKey);
-    }
+    text = text.replace(new RegExp(escapeRegex(subst.actualValueFn()), 'g'), subst.opaqueKey);
   }
   return text;
 }
@@ -141,9 +139,7 @@ function substituteWithRealValues(text) {
   var substitutions = globalOptions.substitutions;
   for (var i=0; i<substitutions.length; i++) {
     var subst = substitutions[i];
-    while (text.indexOf(subst.opaqueKey) > -1) {
-      text = text.replace(subst.opaqueKey, subst.actualValueFn());
-    }
+    text = text.replace(new RegExp(escapeRegex(subst.opaqueKey), 'g'), subst.actualValueFn());
   }
   return text;
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "colors": "^1.1.2",
+    "escape-string-regexp": "1.0.5",
     "express": "^4.14.0",
     "http-proxy": "^1.15.2",
     "levenshtein": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   },
   "dependencies": {
     "colors": "^1.1.2",
-    "escape-string-regexp": "1.0.5",
     "express": "^4.14.0",
     "http-proxy": "^1.15.2",
     "levenshtein": "^1.0.5",

--- a/test/util.js
+++ b/test/util.js
@@ -56,13 +56,21 @@ describe('utils.js', function() {
      var text = substituteWithOpaqueKeys('A:<OPAQUE1>:B:<OPAQUE2>:C:realvalue1:D:realvalue2');
      text.should.equal('A:<OPAQUE1>:B:<OPAQUE2>:C:<OPAQUE1>:D:<OPAQUE2>');
    });
+
+   it('should substitute multiple real values with opaque keys', function () {
+     var valfn1 = function() {return 'realvalue1'; };
+     addSubstitution('<OPAQUE1>', valfn1);
+
+     var text = substituteWithOpaqueKeys('A:<OPAQUE1>:B:<OPAQUE1>:C:realvalue1:D:realvalue1');
+     text.should.equal('A:<OPAQUE1>:B:<OPAQUE1>:C:<OPAQUE1>:D:<OPAQUE1>');
+   });
  });
 
  describe('#substituteWithRealValues', function() {
    const substituteWithRealValues= sepiaUtil.substituteWithRealValues;
    const addSubstitution = sepiaUtil.addSubstitution;
 
-   it('should substitute opaque keys with opaque keys', function () {
+   it('should substitute opaque keys with real values', function () {
      var valfn1 = function() {return 'realvalue1'; };
      var valfn2 = function() {return 'realvalue2'; };
      addSubstitution('<OPAQUE1>', valfn1);
@@ -70,6 +78,14 @@ describe('utils.js', function() {
 
      var text = substituteWithRealValues('A:<OPAQUE1>:B:<OPAQUE2>:C:realvalue1:D:realvalue2');
      text.should.equal('A:realvalue1:B:realvalue2:C:realvalue1:D:realvalue2');
+   });
+
+   it('should substitute multiple instances of opaque keys with real values', function () {
+     var valfn1 = function() {return 'realvalue1'; };
+     addSubstitution('<OPAQUE1>', valfn1);
+
+     var text = substituteWithRealValues('A:<OPAQUE1>:B:<OPAQUE1>:C:realvalue1:D:realvalue1');
+     text.should.equal('A:realvalue1:B:realvalue1:C:realvalue1:D:realvalue1');
    });
  });
 


### PR DESCRIPTION
I was trying out the datetime filter and was trying to use the same substitution in multiple places. It appeared the the substitution only replaced the first instance of the key.

Example:
```
{
  ...
  created_at: "NOW_DATETIME_UTC",
  updated_at: "NOW_DATETIME_UTC"
}
```

**Before:**
```
{
  ...
  created_at:  "2017-02-23T21:59:52Z",
  updated_at: "NOW_DATETIME_UTC"
}
```

I updated the substitution methods to replace _every_ instance of the key instead of just the first one that's found.

**With the fix:**
```
{
  ...
  created_at: "2017-02-23T21:59:52Z",
  updated_at: "2017-02-23T21:59:52Z"
}
```